### PR TITLE
chore: upgrade @babel/traverse package

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^29.5.5",
     "@types/morgan": "^1.9.5",
     "@types/pg": "^8.10.3",
+    "@babel/traverse": ">=7.23.2",
     "concurrently": "^8.2.1",
     "jest": "^29.7.0",
     "nodemon": "^3.0.1",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -43,6 +43,9 @@ dependencies:
     version: 4.14.0
 
 devDependencies:
+  '@babel/traverse':
+    specifier: '>=7.23.2'
+    version: 7.23.2
   '@types/cors':
     specifier: ^2.8.14
     version: 2.8.14
@@ -115,7 +118,7 @@ packages:
       '@babel/helpers': 7.23.1
       '@babel/parser': 7.23.0
       '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.0
+      '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 2.0.0
       debug: 4.3.4
@@ -227,7 +230,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.0
+      '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
@@ -395,8 +398,8 @@ packages:
       '@babel/types': 7.23.0
     dev: true
 
-  /@babel/traverse@7.23.0:
-    resolution: {integrity: sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==}
+  /@babel/traverse@7.23.2:
+    resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.13


### PR DESCRIPTION
upgrade @babel/traverse package due to security risk CVE-2023-45133.